### PR TITLE
Disallow prototype path override - checking magic attributes

### DIFF
--- a/poc.js
+++ b/poc.js
@@ -1,0 +1,6 @@
+var a = require("./dist");
+const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
+var obj = {};
+console.log("Before : " + {}.polluted);
+a.assign(obj, payload);
+console.log("After : " + {}.polluted);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -63,4 +63,11 @@ describe("assign", () => {
       }
     });
   });
+
+  it("should throw when unsafe path encountered", () => {
+    const payload = JSON.parse(
+      '{"__proto__":{"polluted":"Yes! Its Polluted"}}'
+    );
+    expect(() => assign({}, payload)).toThrow();
+  });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -64,10 +64,8 @@ describe("assign", () => {
     });
   });
 
-  it("should throw when unsafe path encountered", () => {
-    const payload = JSON.parse(
-      '{"__proto__":{"polluted":"Yes! Its Polluted"}}'
-    );
-    expect(() => assign({}, payload)).toThrow();
+  it("should ignore when unsafe path encountered", () => {
+    const payload = { __proto__: { polluted: "Yes! Its Polluted" } };
+    expect(assign({}, payload)).toStrictEqual({});
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,8 +33,16 @@ export function assign<T>(target: T, value: DeepPartial<T>) {
 
   if (typeof target === "object" && typeof value === "object") {
     for (const key of Object.keys(value)) {
-      if (isProtoPath(target, key)) continue;
-      (target as any)[key] = assign((target as any)[key], (value as any)[key]);
+      if (isProtoPath(target, key)) {
+        target = Object.defineProperty(target, key, {
+          value: (value as any)[key]
+        });
+      } else {
+        (target as any)[key] = assign(
+          (target as any)[key],
+          (value as any)[key]
+        );
+      }
     }
 
     return target;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,8 @@ export type DeepPartial<T> = {
     : T[K];
 };
 
-function disallowProtoPath(path: any, key: string) {
-  if (path[key] === Object.prototype) {
-    throw new Error("Unsafe path encountered: " + key);
-  }
+function isProtoPath(path: any, key: string) {
+  return path[key] === Object.prototype;
 }
 
 /**
@@ -35,7 +33,7 @@ export function assign<T>(target: T, value: DeepPartial<T>) {
 
   if (typeof target === "object" && typeof value === "object") {
     for (const key of Object.keys(value)) {
-      disallowProtoPath(target, key);
+      if (isProtoPath(target, key)) continue;
       (target as any)[key] = assign((target as any)[key], (value as any)[key]);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,12 @@ export type DeepPartial<T> = {
     : T[K];
 };
 
+function disallowProtoPath(path: any, key: string) {
+  if (path[key] === Object.prototype) {
+    throw new Error("Unsafe path encountered: " + key);
+  }
+}
+
 /**
  * Simple recursive assign of objects.
  */
@@ -18,7 +24,7 @@ export function assign<T>(target: T, value: DeepPartial<T>) {
   if (Array.isArray(value)) {
     if (Array.isArray(target)) {
       for (const item of value) {
-        target.push(item);
+        (target as Array<string>).push(item);
       }
 
       return target;
@@ -29,6 +35,7 @@ export function assign<T>(target: T, value: DeepPartial<T>) {
 
   if (typeof target === "object" && typeof value === "object") {
     for (const key of Object.keys(value)) {
+      disallowProtoPath(target, key);
       (target as any)[key] = assign((target as any)[key], (value as any)[key]);
     }
 


### PR DESCRIPTION
### 📊 Metadata *

`@borderlesslabs/assign` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40borderlesslabs%2Fassign/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```
// poc.js
var a = require("@borderlesslabs/assign")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
a.assign(obj, payload);
console.log("After : " + {}.polluted);
```

2. Execute the following commands in the terminal:

```
npm i @borderlesslabs/assign # Install affected module
node poc.js #  Run the PoC
```

3. Check the output:

```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/107379336-d447f100-6b12-11eb-88e1-3bd4c5694c92.png)

After:
![image](https://user-images.githubusercontent.com/64132745/107540969-a20ac200-6bec-11eb-9951-996f779ba4ab.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/107380200-ab742b80-6b13-11eb-99f3-276a505f6725.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1832
