### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -63,4 +63,11 @@ describe("assign", () => {
       }
     });
   });
+
+  it("should not pollute prototype", () => {
+    const result = assign({}, JSON.parse('{"__proto__": {"polluted": true}}'));
+
+    expect(result).toStrictEqual({});
+    expect(Object.keys(Object.prototype).includes("polluted")).toBe(false);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,13 @@ export type DeepPartial<T> = {
 };
 
 /**
+ * Blacklist certain keys to prevent Prototype Pollution
+ */
+function isPrototypePolluted(key: any) {
+  return ["__proto__", "constructor", "prototype"].includes(key);
+}
+
+/**
  * Simple recursive assign of objects.
  */
 export function assign<T>(target: T, value: DeepPartial<T>) {
@@ -29,6 +36,7 @@ export function assign<T>(target: T, value: DeepPartial<T>) {
 
   if (typeof target === "object" && typeof value === "object") {
     for (const key of Object.keys(value)) {
+      if (isPrototypePolluted(key)) continue;
       (target as any)[key] = assign((target as any)[key], (value as any)[key]);
     }
 


### PR DESCRIPTION
### :bar_chart: Metadata *

`@borderlesslabs/assign` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40borderlesslabs%2Fassign

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var a = require("@borderlesslabs/assign")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
a.assign(obj, payload);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i @borderlesslabs/assign # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

*I've added unit tests for Prototype Pollution*

![image](https://user-images.githubusercontent.com/43996156/105163624-27450e80-5b3a-11eb-9da9-cf4a879e89e8.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
